### PR TITLE
Добавляет минимальную ширину для body

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -37,6 +37,7 @@ body {
   margin: 0 auto;
   display: flex;
   flex-direction: column;
+  min-width: 1440px;
   min-height: 100%;
   font-family: "Rubik", sans-serif;
   font-size: 18px;


### PR DESCRIPTION
По макету размер страницы 1440px. Чтобы по Pixel Perfect макет встал сразу по размерам, выставляю минимальную ширину. Но на маленьких экранах появляется горизонтальная прокрутка.